### PR TITLE
Vagrant up was failing bc of an incorrect env var, and diffstat.proto…

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |config|
       echo 'export GO111MODULE=on' | sudo tee -a /etc/bash.bashrc
       export GOPATH=$HOME/go
       export GO111MODULE=on
-      echo 'export PATH=$PATH:$GOROOT/bin' | sudo tee -a /etc/bash.bashrc
+      echo 'export PATH=$PATH:$GOPATH/bin' | sudo tee -a /etc/bash.bashrc
       export PATH=$PATH:$GOPATH/bin
 
       sudo chown -R $(id -u):$(id -g) $HOME/go

--- a/models/bitbucket/generate.go
+++ b/models/bitbucket/generate.go
@@ -1,4 +1,4 @@
 package bitbucket
 
-//go:generate  protoc --go_out=plugins=grpc:pb/ -I . -I$GOPATH/src common.proto commonevententities.proto projectrootdir.proto webhook.proto respositories.proto
+//go:generate  protoc --go_out=plugins=grpc:pb/ -I . -I$GOPATH/src common.proto commonevententities.proto projectrootdir.proto webhook.proto respositories.proto diffstat.proto
 //go:generate protoc-go-inject-tag -input=pb/commonevententities.pb.go

--- a/models/generate.go
+++ b/models/generate.go
@@ -1,6 +1,6 @@
 package models
 
-//go:generate protoc --go_out=plugins=grpc:pb/ -I=. -I$GOPATH/src -I${GOPATH}/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.5.1/third_party/googleapis/ -I ${GOPATH}/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.5.1 --grpc-gateway_out=logtostderr=true:pb --swagger_out=logtostderr=true:pb guideocelot.proto storage.proto build.proto creds.proto vcshandler.proto werkerserver.proto
+//go:generate protoc --go_out=plugins=grpc:pb/ -I=. -I$GOPATH/src -I${GOPATH}/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.6.2/third_party/googleapis/ -I ${GOPATH}/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.6.2 --grpc-gateway_out=logtostderr=true:pb --swagger_out=logtostderr=true:pb guideocelot.proto storage.proto build.proto creds.proto vcshandler.proto werkerserver.proto
 
 //go:generate protoc-go-inject-tag -input=pb/guideocelot.pb.go
 //go:generate protoc-go-inject-tag -input=pb/build.pb.go


### PR DESCRIPTION
… wasn't being generated. Updating version for grpc ecosystem protos too.

Tested with `vagrant up` - which completed successfully

Ran each of the server components and the output was fine - that is, no errors. This should fix the broken Vagrant workflow. 