### PR TITLE
Fixings minor deployment issues

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "infra" do |infra|
     infra.vm.box = "ubuntu/bionic64"
+    infra.vm.hostname = "infra"
     infra.vm.provider :virtualbox do |vb|
       vb.name = "infra"
       vb.memory = "2048"
@@ -32,6 +33,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "ocelot", primary: true do |ocelot|
     ocelot.vm.box = "ubuntu/bionic64"
+    ocelot.vm.hostname = "ocelot"
     ocelot.vm.provider :virtualbox do |vb|
       vb.name = "ocelot"
       vb.memory = "2048"

--- a/deploy/ocelot-playbook.yml
+++ b/deploy/ocelot-playbook.yml
@@ -1,6 +1,6 @@
 # Ansible 2.7.x
 ---
-- hosts: infra 
+- hosts: ocelot
   roles:
   - vagrant_common
   - vagrant_ocelot_dev


### PR DESCRIPTION
There was a typo in the ocelot playbook that configured
the infra box instead of the ocelot box.

Also I added configuration to set the hostname of each box
to match their vagrant inventory labels.